### PR TITLE
サンプルケース取得処理の修正

### DIFF
--- a/libpycoder/judge.py
+++ b/libpycoder/judge.py
@@ -24,6 +24,7 @@ class Judge:
 
     def test(self, diff=None, verbose=False) -> bool:
         print('test num: {}'.format(len(self.test_cases)))
+        all_result = True
         for test in self.test_cases:
             test_input = test[0]
             test_output = test[1]
@@ -41,12 +42,13 @@ class Judge:
             # --diffオプションを指定した場合は誤差を判定する
             if diff: result = self.judge_diff(actual, expected, diff)
             else:    result = self.judge_equal(actual, expected)
+            all_result &= result
 
             with open(self.tests_dir + test_input) as f: input_val = f.read().rstrip()
 
             # Show results
             self.print_result(result, input_val, actual, expected, verbose)
-        return result
+        return all_result
 
     def run_program(self, target: str, target_input:str) -> str:
         # ex: python <atcoder-dir-path>/ABC/134/A.py < <atcoder-dir-path>/ABC/134/tests/A/00_input.txt

--- a/libpycoder/pathmanager.py
+++ b/libpycoder/pathmanager.py
@@ -28,11 +28,30 @@ class PathManager:
         PathManager.ATCODER_DIR = res
 
     def get_prob_url(self, prob_type):
+        """指定した問題のurlを返す
+        !! 注意 !!
+        コンテストの種類、番号、問題のタイプが必ずしも一致しないため、
+        get_contest_urlの使用して正しいurlを取得することを推奨
+        Args:
+            prob_type: 問題の種類(a, b, c, ...)
+        Returns:
+            prob_url: 指定した問題のurl
+        """
         prob_url = \
             PathManager.CONTEST_URL + self.contest_type + self.contest_id \
             + '/tasks/' \
             + self.contest_type + self.contest_id + '_' + prob_type
         return prob_url
+
+    def get_contest_url(self) -> str:
+        """contest問題一覧ページのurlを返す
+        Args:
+        Returns:
+            contest_url: コンテストの問題一覧ページのurl
+        """
+        contest_url = \
+            PathManager.CONTEST_URL + self.contest_type + self.contest_id + '/tasks'
+        return contest_url
 
     def get_submit_url(self):
         return PathManager.SUBMIT_URL

--- a/libpycoder/testmake.py
+++ b/libpycoder/testmake.py
@@ -10,6 +10,8 @@ class TestMaker():
         self.contest_type = contest_type
         self.contest_id = contest_id
         self.pm = PathManager(contest_type, contest_id)
+        self.ac = AtConnector()
+        self.ac.login()
 
     def __extract_unused_data(self, soup_obj):
         # 英語ケースを削除
@@ -21,14 +23,14 @@ class TestMaker():
         return soup_obj
 
     def fetch_sample_cases(self):
-        ac = AtConnector()
-        ac.login()
         problems = ['a', 'b', 'c', 'd', 'e', 'f']
+        prob_urls = self.get_prob_urls_from_contest_page()
         for p in problems:
             print('*', end='')
-            url = self.pm.get_prob_url(p)
+            url = prob_urls[p]
+            if url == '': continue
             # login済みのセッションを利用して、HTMLを取得する
-            res = ac.session.get(url)
+            res = self.ac.session.get(url)
             # レスポンスの HTML から BeautifulSoup オブジェクトを作る
             soup = BeautifulSoup(res.text, 'html5lib')
             soup = self.__extract_unused_data(soup)
@@ -48,12 +50,15 @@ class TestMaker():
                 with open(file_dir + oname, 'w') as f: f.write(v[1])
         print('\nDone!')
 
-    def get_prob_urls_from_contest_page(self) -> List[str]:
-        ac = AtConnector()
-        ac.login
+    def get_prob_urls_from_contest_page(self):
+        """コンテスト問題一覧ページから各問題のurlを取得して返す
+        Args:
+        Returns:
+            urls: 各問題のurl
+        """
         contest_url = self.pm.get_contest_url()
-        res = ac.session.get(contest_url)
-        soup = BeautifulSoup(res.txt, 'html5lib')
+        res = self.ac.session.get(contest_url)
+        soup = BeautifulSoup(res.text, 'html5lib')
 
         urls = {'a': '', 'b': '', 'c': '', 'd': '', 'e': '', 'f': ''}
         for tbody in soup.find_all('tbody'):
@@ -63,7 +68,6 @@ class TestMaker():
                 url = item.get('href')
                 urls[prob_type] = 'https://atcoder.jp' + url
         return urls
-
 
     def add_test_case(self, problem_type):
         print('Input:')

--- a/libpycoder/testmake.py
+++ b/libpycoder/testmake.py
@@ -46,8 +46,24 @@ class TestMaker():
                 oname = '0' + str(k) + '_output.txt'
                 with open(file_dir + iname, 'w') as f: f.write(v[0])
                 with open(file_dir + oname, 'w') as f: f.write(v[1])
-
         print('\nDone!')
+
+    def get_prob_urls_from_contest_page(self) -> List[str]:
+        ac = AtConnector()
+        ac.login
+        contest_url = self.pm.get_contest_url()
+        res = ac.session.get(contest_url)
+        soup = BeautifulSoup(res.txt, 'html5lib')
+
+        urls = {'a': '', 'b': '', 'c': '', 'd': '', 'e': '', 'f': ''}
+        for tbody in soup.find_all('tbody'):
+            for tr in tbody.find_all('tr'):
+                item = tr.find('td').find('a')
+                prob_type = item.contents[0].lower()
+                url = item.get('href')
+                urls[prob_type] = 'https://atcoder.jp' + url
+        return urls
+
 
     def add_test_case(self, problem_type):
         print('Input:')


### PR DESCRIPTION
- 問題のurlをコンテストの種類、番号でひとつひとつ構成するのではなく、問題一覧ページからスクレイピングするように修正

close #15 